### PR TITLE
Feat/drop appassembler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,22 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.2</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>lib/</classpathPrefix>
+                            <mainClass>org.vaadin.example.MainKt</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+
             <!-- needs to be before vaadin-maven-plugin: https://github.com/vaadin/flow/issues/20246 -->
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
@@ -139,7 +155,6 @@
                 </configuration>
             </plugin>
 
-            <!-- JUnit 5 requires Surefire version 2.22.0 or higher -->
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.3.1</version>
@@ -170,13 +185,8 @@
             <!-- creates the "zip" distribution out of the app that appassembler produced -->
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.7.1</version>
                 <configuration>
-                    <archive>
-                        <manifest>
-                            <mainClass>com.vaadin.starter.skeleton.Main</mainClass>
-                        </manifest>
-                    </archive>
                     <descriptors>
                         <descriptor>src/main/assembly/zip.xml</descriptor>
                     </descriptors>

--- a/pom.xml
+++ b/pom.xml
@@ -160,28 +160,6 @@
                 <version>3.3.1</version>
             </plugin>
 
-            <!-- creates an executable app -->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>appassembler-maven-plugin</artifactId>
-                <version>2.1.0</version>
-                <configuration>
-                    <programs>
-                        <program>
-                            <mainClass>org.vaadin.example.MainKt</mainClass>
-                            <name>app</name>
-                        </program>
-                    </programs>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>assemble</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <!-- creates the "zip" distribution out of the app that appassembler produced -->
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <jvmTarget>17</jvmTarget>
+                    <jvmTarget>21</jvmTarget>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,18 @@
                     <jvmTarget>21</jvmTarget>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-maven-plugin</artifactId>
+                <version>${vaadin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build-frontend</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -190,33 +202,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>production</id>
-            <dependencies>
-                <!-- exclude vaadin-dev from production build -->
-                <dependency>
-                    <groupId>com.vaadin</groupId>
-                    <artifactId>vaadin-dev</artifactId>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.vaadin</groupId>
-                        <artifactId>vaadin-maven-plugin</artifactId>
-                        <version>${vaadin.version}</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>build-frontend</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -114,21 +114,6 @@
                 <version>3.13.0</version>
             </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.4.2</version>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <addClasspath>true</addClasspath>
-                            <classpathPrefix>lib/</classpathPrefix>
-                            <mainClass>org.vaadin.example.MainKt</mainClass>
-                        </manifest>
-                    </archive>
-                </configuration>
-            </plugin>
-
             <!-- needs to be before vaadin-maven-plugin: https://github.com/vaadin/flow/issues/20246 -->
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/src/main/assembly/zip.xml
+++ b/src/main/assembly/zip.xml
@@ -7,11 +7,31 @@
         <format>tar.gz</format>
     </formats>
     <includeBaseDirectory>false</includeBaseDirectory>
+  <!-- Include your project JAR in the root -->
+    <files>
+        <file>
+            <source>${project.build.directory}/${project.artifactId}-${project.version}.jar</source>
+            <outputDirectory>/</outputDirectory>
+        </file>
+    </files>
+    <!-- Include scripts in bin/ and make them executable -->
     <fileSets>
         <fileSet>
-            <directory>target/appassembler</directory>
-            <outputDirectory>/</outputDirectory>
-            <fileMode>0755</fileMode>
+            <directory>${project.basedir}/src/main/scripts</directory> <!-- Where your script templates are -->
+            <outputDirectory>bin</outputDirectory>
+            <fileMode>0755</fileMode> <!-- Executable permissions -->
         </fileSet>
     </fileSets>
+   <!-- Copy dependencies to lib/, excluding optional ones -->
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>lib</outputDirectory>
+            <useProjectArtifact>false</useProjectArtifact>
+            <unpack>false</unpack>
+            <scope>runtime</scope>
+            <excludes>
+                <exclude>com.vaadin:vaadin-dev</exclude>
+            </excludes>
+        </dependencySet>
+    </dependencySets> 
 </assembly>

--- a/src/main/assembly/zip.xml
+++ b/src/main/assembly/zip.xml
@@ -29,6 +29,7 @@
             <useProjectArtifact>false</useProjectArtifact>
             <unpack>false</unpack>
             <scope>runtime</scope>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
             <excludes>
                 <exclude>com.vaadin:vaadin-dev</exclude>
             </excludes>

--- a/src/main/assembly/zip.xml
+++ b/src/main/assembly/zip.xml
@@ -7,13 +7,6 @@
         <format>tar.gz</format>
     </formats>
     <includeBaseDirectory>false</includeBaseDirectory>
-  <!-- Include your project JAR in the root -->
-    <files>
-        <file>
-            <source>${project.build.directory}/${project.artifactId}-${project.version}.jar</source>
-            <outputDirectory>/</outputDirectory>
-        </file>
-    </files>
     <!-- Include scripts in bin/ and make them executable -->
     <fileSets>
         <fileSet>
@@ -22,13 +15,11 @@
             <fileMode>0755</fileMode> <!-- Executable permissions -->
         </fileSet>
     </fileSets>
-   <!-- Copy dependencies to lib/, excluding optional ones -->
+   <!-- Copy dependencies to lib/, excluding vaadin-dev ones -->
     <dependencySets>
         <dependencySet>
             <outputDirectory>lib</outputDirectory>
-            <useProjectArtifact>false</useProjectArtifact>
             <unpack>false</unpack>
-            <scope>runtime</scope>
             <useTransitiveFiltering>true</useTransitiveFiltering>
             <excludes>
                 <exclude>com.vaadin:vaadin-dev</exclude>

--- a/src/main/scripts/app
+++ b/src/main/scripts/app
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e -o pipefail
+BASE_DIR=$(dirname "$0")/..
+cd $BASE_DIR/lib
+CLASSPATH=$(ls|tr '\n' ':')
+java -cp "$CLASSPATH" org.vaadin.example.MainKt "$@"


### PR DESCRIPTION
Mojohaus AppAssembler is dead: https://github.com/mojohaus/appassembler

Let's go back to Maven Assembly + scripts since there's no other way to package Maven apps (no Gradle Application plugin)